### PR TITLE
Modification to remove non-zero p_max_pu for solar profiles during night times

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -605,6 +605,7 @@ sector:
   biogas_upgrading_cc: false
   conventional_generation:
     OCGT: gas
+  keep_existing_capacities: false
   biomass_to_liquid: false
   biosng: false
   limit_max_growth:

--- a/doc/configtables/sector.csv
+++ b/doc/configtables/sector.csv
@@ -136,6 +136,7 @@ biomass_spatial,--,"{true, false}",Add option for resolving biomass demand regio
 biomass_transport,--,"{true, false}",Add option for transporting solid biomass between nodes
 biogas_upgrading_cc,--,"{true, false}",Add option to capture CO2 from biomass upgrading
 conventional_generation,,,Add a more detailed description of conventional carriers. Any power generation requires the consumption of fuel from nodes representing that fuel.
+keep_existing_capacities,--,"{true, false}",Keep existing conventional carriers from the power model. Defaults to false.
 biomass_to_liquid,--,"{true, false}",Add option for transforming solid biomass into liquid fuel with the same properties as oil
 biosng,--,"{true, false}",Add option for transforming solid biomass into synthesis gas with the same properties as natural gas
 limit_max_growth,,,

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,11 +10,14 @@ Release Notes
 Upcoming Release
 ================
 
+* Reverted outdated hotfix for doubled renewable capacity in myopic optimization.
+
 * Added Enhanced Geothermal Systems for generation of electricity and district heat.
   Cost and available capacity assumptions based on `Aghahosseini et al. (2020)
   <https://www.sciencedirect.com/science/article/pii/S0306261920312551>`__.
   See configuration ``sector: enhanced_geothermal`` for details; by default switched off.
 
+* Enable retaining exisiting conventional capacities added in the power only model for sector coupeled applications.
 
 PyPSA-Eur 0.11.0 (25th May 2024)
 =====================================

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -948,6 +948,7 @@ rule prepare_sector_network:
         countries=config_provider("countries"),
         adjustments=config_provider("adjustments", "sector"),
         emissions_scope=config_provider("energy", "emissions"),
+        electricity=config_provider("electricity"),
         RDIR=RDIR,
     input:
         unpack(input_profile_offwind),

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -450,6 +450,7 @@ def attach_conventional_generators(
     ppl,
     conventional_carriers,
     extendable_carriers,
+    renewable_carriers,
     conventional_params,
     conventional_inputs,
     unit_commitment=None,
@@ -470,6 +471,7 @@ def attach_conventional_generators(
         .rename(index=lambda s: f"C{str(s)}")
     )
     ppl["efficiency"] = ppl.efficiency.fillna(ppl.efficiency_r)
+    ppl = ppl.query("carrier not in @renewable_carriers")
 
     # reduce carriers to those in power plant dataset
     carriers = list(set(carriers) & set(ppl.carrier.unique()))
@@ -501,9 +503,9 @@ def attach_conventional_generators(
         )
 
     # Define generators using modified ppl DataFrame
-    caps = ppl.groupby("carrier").p_nom.sum().div(1e3).round(2)
+    caps = ppl.query("carrier not in @renewable_carriers").groupby("carrier").p_nom.sum().div(1e3).round(2)
     logger.info(f"Adding {len(ppl)} generators with capacities [GW] \n{caps}")
-
+    
     n.madd(
         "Generator",
         ppl.index,
@@ -862,6 +864,7 @@ if __name__ == "__main__":
         ppl,
         conventional_carriers,
         extendable_carriers,
+        renewable_carriers,
         params.conventional,
         conventional_inputs,
         unit_commitment=unit_commitment,

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -200,6 +200,10 @@ if __name__ == "__main__":
     ppl = add_custom_powerplants(
         ppl, snakemake.input.custom_powerplants, custom_ppl_query
     )
+    ppl = (
+        ppl.assign(Technology=replace_natural_gas_technology)
+        .assign(Fueltype=replace_natural_gas_fueltype)
+    )
 
     if countries_wo_ppl := set(countries) - set(ppl.Country.unique()):
         logging.warning(f"No powerplants known in: {', '.join(countries_wo_ppl)}")

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -4008,9 +4008,6 @@ if __name__ == "__main__":
             carriers=options.get("conventional_generation").keys(),
             component="generators",
         )
-        print(options.get("conventional_generation").keys())
-        print(n.generators.carrier.unique())
-        martha
     else:
         existing_capacities, existing_efficiencies = 0, None
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -191,6 +191,16 @@ def define_spatial(nodes, options):
         spatial.coal.demand_locations = ["EU"]
         spatial.coal.industry = ["EU coal for industry"]
 
+    # coal chp
+    spatial.coal_chp = SimpleNamespace()
+    spatial.coal_chp.nodes = ["EU coal_chp"]
+    spatial.coal_chp.locations = ["EU"]
+
+    # gas chp
+    spatial.gas_chp = SimpleNamespace()
+    spatial.gas_chp.nodes = ["EU gas_chp"]
+    spatial.gas_chp.locations = ["EU"]
+
     # lignite
     spatial.lignite = SimpleNamespace()
     spatial.lignite.nodes = ["EU lignite"]

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -851,19 +851,17 @@ def prepare_costs(cost_file, params, nyears):
     return costs
 
 
-def add_generation(n, costs):
+def add_generation(n, costs, existing_capacities=0, existing_efficiencies=None):
     logger.info("Adding electricity generation")
 
     nodes = pop_layout.index
 
     fallback = {"OCGT": "gas"}
     conventionals = options.get("conventional_generation", fallback)
-
     for generator, carrier in conventionals.items():
         carrier_nodes = vars(spatial)[carrier].nodes
 
         add_carrier_buses(n, carrier, carrier_nodes)
-
         n.madd(
             "Link",
             nodes + " " + generator,
@@ -874,9 +872,28 @@ def add_generation(n, costs):
             * costs.at[generator, "VOM"],  # NB: VOM is per MWel
             capital_cost=costs.at[generator, "efficiency"]
             * costs.at[generator, "fixed"],  # NB: fixed cost is per MWel
-            p_nom_extendable=True,
+            p_nom_extendable=(
+                True
+                if generator
+                in snakemake.params.electricity.get("extendable_carriers", dict()).get(
+                    "Generator", list()
+                )
+                else False
+            ),    
+            p_nom=(
+                existing_capacities[generator] / existing_efficiencies[generator]
+                if not existing_capacities == 0 else 0
+            ), # NB: existing capacities are MWel     
+            p_max_pu = 0.7 if carrier == "uranium" else 1, # be conservative for nuclear (maintance or unplanned shut downs)
+            p_nom_min=(
+                existing_capacities[generator] if not existing_capacities == 0 else 0
+            ),   
             carrier=generator,
-            efficiency=costs.at[generator, "efficiency"],
+            efficiency=(
+                existing_efficiencies[generator]
+                if existing_efficiencies is not None
+                else costs.at[generator, "efficiency"]
+            ),
             efficiency2=costs.at[carrier, "CO2 intensity"],
             lifetime=costs.at[generator, "lifetime"],
         )
@@ -4015,7 +4032,7 @@ if __name__ == "__main__":
 
     spatial = define_spatial(pop_layout.index, options)
 
-    if snakemake.params.foresight in ["myopic", "perfect"]:
+    if snakemake.params.foresight in ["overnight", "myopic", "perfect"]:
         add_lifetime_wind_solar(n, costs)
 
         conventional = snakemake.params.conventional_carriers
@@ -4026,7 +4043,7 @@ if __name__ == "__main__":
 
     add_co2_tracking(n, costs, options)
 
-    add_generation(n, costs)
+    add_generation(n, costs, existing_capacities, existing_efficiencies)
 
     add_storage_and_grids(n, costs)
 


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
In the commit, I propose removing addition of solar and wind generators inside the attach_conventional_generation function as they are already added in the attach_wind_and_solar function. This creates a duplicity in the generator list creating an offset for solar and wind profiles (p_max_pu)

## Checklist

- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.default.yaml`.
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv`.
- [ ] A release note `doc/release_notes.rst` is added.
