### PR TITLE
Add ability to specify different max hour archetypes for storage technologies

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -100,8 +100,8 @@ electricity:
     contingency: 4000
 
   max_hours:
-    battery: 6
-    H2: 168
+    battery: [6]
+    H2: [168]
 
   extendable_carriers:
     Generator: [solar, solar-hsat, onwind, offwind-ac, offwind-dc, offwind-float, OCGT, CCGT]

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -100,7 +100,7 @@ electricity:
     contingency: 4000
 
   max_hours:
-    battery: [6]
+    li-ion battery: [6]
     H2: [168]
     iron-air battery: [100]
 

--- a/config/config.form.yaml
+++ b/config/config.form.yaml
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: : 2017-2024 The PyPSA-Eur Authors
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#top-level-configuration
+version: 0.13.0
+tutorial: false
+
+logging:
+  level: INFO
+  format: '%(levelname)s:%(name)s:%(message)s'
+
+remote:
+  ssh: ""
+  path: ""
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
+run:
+  prefix: ""
+  name: "test_scenarios"
+  scenarios:
+    enable: false
+    file: config/scenarios.yaml
+  disable_progressbar: false
+  shared_resources:
+    policy: false
+    exclude: []
+  shared_cutouts: true
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#foresight
+foresight: myopic
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#scenario
+# Wildcard docs in https://pypsa-eur.readthedocs.io/en/latest/wildcards.html
+scenario:
+  ll:
+  - v1.27  # v1.x with x according to NEP and TYNDP (existing_capacities=zero)
+  clusters:
+  - 52
+  planning_horizons:
+  - 2035
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#countries
+countries: ['AT', 'BE', 'CH', 'CZ', 'DE', 'DK', 'FR', 'IT', 'LU', 'NL', 'PL', 'SE']
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#snapshots
+snapshots:
+  start: "2013-01-01"
+  end: "2014-01-01"
+  inclusive: 'left'
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#enable
+enable:
+  retrieve: auto
+  retrieve_databundle: true
+  retrieve_cost_data: true
+  build_cutout: false
+  retrieve_cutout: false
+  custom_busmap: false
+  drop_leap_day: true
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#co2-budget
+co2_budget:
+  2035: 0.392 # derived from individual countries carbon emission targets
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#electricity
+electricity:
+  max_hours:
+    battery: 6
+    H2: 168
+    iron-air battery: 100
+  custom_powerplants: false # TODO: Custom PP from EEE project
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#atlite
+atlite:
+  # TODO: weather year - input from FORM
+  default_cutout: europe-2013-sarah3-era5
+  nprocesses: 4
+  show_progress: false
+  cutouts:
+    # use 'base' to determine geographical bounds and time span from config
+    # base:
+      # module: era5
+    europe-2013-sarah3-era5:
+      module: [sarah, era5] # in priority order
+      x: [-12., 42.]
+      y: [33., 72.]
+      dx: 0.3
+      dy: 0.3
+      time: ['2013', '2013']
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#lines
+lines:
+  dynamic_line_rating:
+    activate: false
+    cutout: europe-2013-sarah3-era5
+    correction_factor: 0.95
+    max_voltage_difference: 30 # Glaum & Hofmann, 2022 https://arxiv.org/abs/2208.04716
+    max_line_rating: 1.5 # based on https://www.energysystem2050.net/content/TransnetBW-Study_EnergySystem2050.pdf?v2, p.81
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#transmission_projects
+transmission_projects:
+  enable: false
+  include:
+    tyndp2020: false
+    nep: true
+    manual: false
+  skip:
+  - upgraded_lines
+  - upgraded_links
+  status:
+  - under_construction
+  - in_permitting
+  - confirmed
+    #- planned_not_yet_permitted
+    #- under_consideration
+  new_link_capacity: zero #keep or zero
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#existing-capacities
+# TODO: add option for manual phase out of conventional power plants
+existing_capacities:
+  grouping_years_power: [1920, 1950, 1955, 1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025]
+  grouping_years_heat: [1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2019] # heat grouping years >= baseyear will be ignored
+  threshold_capacity: 10
+  default_heating_lifetime: 20
+  conventional_carriers:
+  - lignite
+  - coal
+  - oil
+  - uranium
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#sector
+sector:
+  transport: true
+  heating: true
+  biomass: false
+  industry: false
+  agriculture: false
+  fossil_fuels: true
+  bev_dsm: true
+  bev_availability: 0.2 # FE input
+  v2g: true
+  land_transport_fuel_cell_share:
+    2035: 0
+  land_transport_electric_share:
+    2035: 0.30 # FE input
+  land_transport_ice_share:
+    2035: 0.70
+  reduce_space_heat_exogenously: true
+  reduce_space_heat_exogenously_factor: # TODO: check this for Germany (Regulation or Ariadne?)
+    2035: 0.11
+  tes: false
+  marginal_cost_storage: 0. #1e-4
+  stores: ["H2"]
+  storage_units: ["battery"]
+  hydrogen_fuel_cell: true
+  hydrogen_turbine: false
+  hydrogen_underground_storage: true
+  hydrogen_underground_storage_locations:
+    # - onshore  # more than 50 km from sea
+  - nearshore    # within 50 km of sea
+    # - offshore
+  H2_network: false
+  gas_network: false
+  H2_retrofit: false
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#costs
+costs:
+  year: 2035 # TODO: change to commit with new cost assumptions
+  version: v0.9.2
+  social_discountrate: 0.02
+  fill_values:
+    FOM: 0
+    VOM: 0
+    efficiency: 1
+    fuel: 0
+    investment: 0
+    lifetime: 25
+    "CO2 intensity": 0
+    "discount rate": 0.07
+  # Marginal and capital costs can be overwritten
+  # capital_cost:
+  #   onwind: 500
+  marginal_cost:
+    solar: 0.01
+    onwind: 0.015
+    offwind: 0.015
+    hydro: 0.
+    H2: 0.
+    electrolysis: 0.
+    fuel cell: 0.
+    battery: 0.
+    battery inverter: 0.
+  emission_prices:
+    enable: false
+    co2: 0.
+    co2_monthly_prices: false
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#clustering
+clustering:
+  focus_weights:
+    DE: 0.6
+  temporal:
+    resolution_sector: 100H #2920SEG # TODO: low for development, change this later

--- a/config/config.form.yaml
+++ b/config/config.form.yaml
@@ -66,7 +66,7 @@ co2_budget:
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#electricity
 electricity:
   max_hours:
-    battery: [4, 6]
+    li-ion battery: [4, 6]
     H2: [168]
     iron-air battery: [100]
   custom_powerplants: false # TODO: Custom PP from EEE project

--- a/config/config.form.yaml
+++ b/config/config.form.yaml
@@ -66,9 +66,8 @@ co2_budget:
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#electricity
 electricity:
   max_hours:
-    battery: 6
-    H2: 168
-    iron-air battery: 100
+    battery: [4, 6]
+    H2: [168]
   custom_powerplants: false # TODO: Custom PP from EEE project
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#atlite

--- a/config/config.form.yaml
+++ b/config/config.form.yaml
@@ -68,7 +68,6 @@ electricity:
   max_hours:
     battery: [4, 6]
     H2: [168]
-    iron-air battery: [100]
   custom_powerplants: false # TODO: Custom PP from EEE project
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#atlite

--- a/doc/configtables/electricity.csv
+++ b/doc/configtables/electricity.csv
@@ -14,8 +14,9 @@ operational_reserve,,,Settings for reserve requirements following `GenX <https:/
 -- epsilon_vres,--,float,share of total renewable supply
 -- contingency,MW,float,fixed reserve capacity
 max_hours,,,
--- battery,h,List of floats,Maximum state of charge capacity of the battery archetype in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_.
--- H2,h,List of floats,Maximum state of charge capacity of the hydrogen storage archetype in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_.
+-- battery,h,List of floats,Maximum state of charge capacity of the battery archetypes in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_.
+-- H2,h,List of floats,Maximum state of charge capacity of the hydrogen storage archetypes in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_.
+
 extendable_carriers,,,
 -- Generator,--,Any extendable carrier,"Defines existing or non-existing conventional and renewable power plants to be extendable during the optimization. Conventional generators can only be built/expanded where already existent today. If a listed conventional carrier is not included in the ``conventional_carriers`` list, the lower limit of the capacity expansion is set to 0."
 -- StorageUnit,--,"Any subset of {'battery','H2'}",Adds extendable storage units (battery and/or hydrogen) at every node/bus after clustering without capacity limits and with zero initial capacity.

--- a/doc/configtables/electricity.csv
+++ b/doc/configtables/electricity.csv
@@ -14,8 +14,8 @@ operational_reserve,,,Settings for reserve requirements following `GenX <https:/
 -- epsilon_vres,--,float,share of total renewable supply
 -- contingency,MW,float,fixed reserve capacity
 max_hours,,,
--- battery,h,float,Maximum state of charge capacity of the battery in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_.
--- H2,h,float,Maximum state of charge capacity of the hydrogen storage in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_.
+-- battery,h,List of floats,Maximum state of charge capacity of the battery archetype in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_.
+-- H2,h,List of floats,Maximum state of charge capacity of the hydrogen storage archetype in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_.
 extendable_carriers,,,
 -- Generator,--,Any extendable carrier,"Defines existing or non-existing conventional and renewable power plants to be extendable during the optimization. Conventional generators can only be built/expanded where already existent today. If a listed conventional carrier is not included in the ``conventional_carriers`` list, the lower limit of the capacity expansion is set to 0."
 -- StorageUnit,--,"Any subset of {'battery','H2'}",Adds extendable storage units (battery and/or hydrogen) at every node/bus after clustering without capacity limits and with zero initial capacity.

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -112,6 +112,7 @@ network with **zero** initial capacity:
 
 import logging
 from pathlib import Path
+import warnings
 from typing import Dict, List
 
 import numpy as np
@@ -996,6 +997,14 @@ if __name__ == "__main__":
 
     params = snakemake.params
     max_hours = params.electricity["max_hours"]
+    # deprecation warning and casting float values to list of float values for max_hours per carrier
+    for carrier in max_hours.keys():
+        if not isinstance(max_hours[carrier], list):
+            warnings.warn(
+                "The 'max_hours' configuration as a float is deprecated and will be removed in future versions. Please use a list instead.",
+                DeprecationWarning,
+            )
+            max_hours[carrier] = [max_hours[carrier]]
     landfall_lengths = {
         tech: settings["landfall_length"]
         for tech, settings in params.renewable.items()

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -279,7 +279,7 @@ def load_costs(tech_costs, config, max_hours, Nyears=1.0):
             costs.loc["battery inverter"],
             max_hours=max_hour,
         )
-    # cost for default li-ion battery
+    # cost for default li-ion battery which will be the first max_hour archetype
     costs.loc[f"li-ion battery"] = costs_for_storage(
         costs.loc["battery storage"],
         costs.loc["battery inverter"],
@@ -293,12 +293,12 @@ def load_costs(tech_costs, config, max_hours, Nyears=1.0):
             costs.loc["electrolysis"],
             max_hours=max_hour,
         )
-    # cost for default 168h H2 underground storage
+    # cost for default H2 underground storage which will be the first max_hour archetype
     costs.loc[f"H2"] = costs_for_storage(
         costs.loc["hydrogen storage underground"],
         costs.loc["fuel cell"],
         costs.loc["electrolysis"],
-        max_hours=168,
+        max_hours=max_hours["H2"][0],
     )
 
     for attr in ("marginal_cost", "capital_cost"):

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -282,7 +282,7 @@ def load_costs(tech_costs, config, max_hours, Nyears=1.0):
     costs.loc[f"battery"] = costs_for_storage(
         costs.loc["battery storage"],
         costs.loc["battery inverter"],
-        max_hours=6,
+        max_hours=max_hours["battery"][0],
     )
 
     for max_hour in max_hours["H2"]:

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -998,7 +998,7 @@ if __name__ == "__main__":
     params = snakemake.params
     max_hours = params.electricity["max_hours"]
     # deprecation warning and casting float values to list of float values for max_hours per carrier
-    for carrier in max_hours.keys():
+    for carrier in max_hours:
         if not isinstance(max_hours[carrier], list):
             warnings.warn(
                 "The 'max_hours' configuration as a float is deprecated and will be removed in future versions. Please use a list instead.",

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1460,9 +1460,6 @@ def get_salt_caverns(cavern_types, fn_h2_cavern):
 def add_storageunits(n, costs, carriers, max_hours):
     nodes = pop_layout.index
 
-    missing_carriers = list(set(carriers).difference(n.carriers.index))
-    n.add("Carrier", missing_carriers)
-
     # check for not implemented storage technologies
     implemented = ["H2", "li-ion battery", "iron-air battery"]
     not_implemented = list(set(carriers).difference(implemented))
@@ -1471,6 +1468,8 @@ def add_storageunits(n, costs, carriers, max_hours):
         logger.warning(
             f"{not_implemented} are not yet implemented as Storage technologies in PyPSA-Eur"
         )
+    missing_carriers = list(set(available_carriers).difference(n.carriers.index))
+    n.add("Carrier", missing_carriers)
 
     lookup_store = {"H2": "electrolysis", "li-ion battery": "battery inverter", "iron-air battery": "iron-air battery charge"}
     lookup_dispatch = {"H2": "fuel cell", "li-ion battery": "battery inverter", "iron-air battery": "iron-air battery discharge"}
@@ -1533,16 +1532,16 @@ def add_storageunits(n, costs, carriers, max_hours):
 def add_stores(n, costs, carriers):
     nodes = pop_layout.index
 
-    missing_carriers = list(set(carriers).difference(n.carriers.index))
-    n.add("Carrier", missing_carriers)
-
     # check for not implemented storage technologies
     implemented = ["H2", "li-ion battery", "iron-air battery"]
     not_implemented = list(set(carriers).difference(implemented))
+    available_carriers = list(set(carriers).intersection(implemented))
     if len(not_implemented) > 0:
         logger.warning(
             f"{not_implemented} are not yet implemented as Store technologies in PyPSA-Eur"
         )
+    missing_carriers = list(set(available_carriers).difference(n.carriers.index))
+    n.add("Carrier", missing_carriers)
 
     if "H2" in carriers:
         cavern_types = snakemake.params.sector["hydrogen_underground_storage_locations"]

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1103,7 +1103,7 @@ def prepare_costs(cost_file, params, nyears):
         return pd.Series(dict(fixed=capital_cost, lifetime=store["lifetime"]))
 
     max_hours = params["max_hours"]
-    # TODO: stoarge capex might have to be adjusted for different max hour archetypes
+    # TODO: storage capex might have to be adjusted for different max hour archetypes
     for max_hour in max_hours["battery"]:
         costs.loc[f"battery {max_hour}h"] = costs_for_storage(
             costs.loc["battery storage"],

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1103,28 +1103,31 @@ def prepare_costs(cost_file, params, nyears):
         return pd.Series(dict(fixed=capital_cost, lifetime=store["lifetime"]))
 
     max_hours = params["max_hours"]
-    costs.loc["battery"] = costs_for_storage(
-        costs.loc["battery storage"],
-        costs.loc["battery inverter"],
-        max_hours=max_hours["battery"],
-    )
-    costs.loc["home battery"] = costs_for_storage(
-        costs.loc["home battery storage"],
-        costs.loc["home battery inverter"],
-        max_hours=max_hours["battery"],
-    )
-    costs.loc["H2 underground"] = costs_for_storage(
-        costs.loc["hydrogen storage underground"],
-        costs.loc["fuel cell"],
-        costs.loc["electrolysis"],
-        max_hours=max_hours["H2"],
-    )
-    costs.loc["H2 tank"] = costs_for_storage(
-        costs.loc["hydrogen storage tank type 1 including compressor"],
-        costs.loc["fuel cell"],
-        costs.loc["electrolysis"],
-        max_hours=max_hours["H2"],
-    )
+    # TODO: stoarge capex might have to be adjusted for different max hour archetypes
+    for max_hour in max_hours["battery"]:
+        costs.loc[f"battery {max_hour}h"] = costs_for_storage(
+            costs.loc["battery storage"],
+            costs.loc["battery inverter"],
+            max_hours=max_hour,
+        )
+        costs.loc[f"home battery {max_hour}h"] = costs_for_storage(
+            costs.loc["home battery storage"],
+            costs.loc["home battery inverter"],
+            max_hours=max_hour,
+        )
+    for max_hour in max_hours["H2"]:
+        costs.loc[f"H2 underground {max_hour}h"] = costs_for_storage(
+            costs.loc["hydrogen storage underground"],
+            costs.loc["fuel cell"],
+            costs.loc["electrolysis"],
+            max_hours=max_hour,
+        )
+        costs.loc[f"H2 tank {max_hour}h"] = costs_for_storage(
+            costs.loc["hydrogen storage tank type 1 including compressor"],
+            costs.loc["fuel cell"],
+            costs.loc["electrolysis"],
+            max_hours=max_hour,
+        )
 
     return costs
 
@@ -1370,22 +1373,22 @@ def insert_electricity_distribution_grid(n, costs):
     elif "battery" in snakemake.params.sector["storage_units"]:
         n.add("Carrier", "home battery")
         max_hours = snakemake.params.max_hours
-
-        n.add(
-            "StorageUnit",
-            nodes,
-            suffix=" home battery",
-            bus=nodes + " low voltage",
-            carrier="home battery",
-            p_nom_extendable=True,
-            capital_cost=costs.at["home battery", "fixed"],
-            marginal_cost=options["marginal_cost_storage"],
-            efficiency_store=costs.at["home battery inverter", "efficiency"] ** 0.5,
-            efficiency_dispatch=costs.at["home battery inverter", "efficiency"] ** 0.5,
-            max_hours=max_hours["battery"],
-            cyclic_state_of_charge=True,
-            lifetime=costs.at["home battery storage", "lifetime"],
-        )
+        for max_hour in max_hours["battery"]:
+            n.add(
+                "StorageUnit",
+                nodes,
+                suffix=f" home battery {max_hour}h",
+                bus=nodes + " low voltage",
+                carrier="home battery",
+                p_nom_extendable=True,
+                capital_cost=costs.at[f"home battery {max_hour}h", "fixed"],
+                marginal_cost=options["marginal_cost_storage"],
+                efficiency_store=costs.at["home battery inverter", "efficiency"] ** 0.5,
+                efficiency_dispatch=costs.at["home battery inverter", "efficiency"] ** 0.5,
+                max_hours=max_hour,
+                cyclic_state_of_charge=True,
+                lifetime=costs.at["home battery storage", "lifetime"],
+            )
 
 
 def insert_gas_distribution_costs(n, costs):
@@ -1464,56 +1467,57 @@ def add_storageunits(n, costs, carriers, max_hours):
     lookup_dispatch = {"H2": "fuel cell", "battery": "battery inverter"}
 
     for carrier in available_carriers:
-        roundtrip_correction = 0.5 if carrier == "battery" else 1
-        if carrier == "H2":
-            cavern_types = snakemake.params.sector[
-                "hydrogen_underground_storage_locations"
-            ]
-            fn_h2_cavern = snakemake.input.h2_cavern
-            h2_caverns = get_salt_caverns(cavern_types, fn_h2_cavern)
-            # h2_caverns will be empty pd.Series if hydrogen_underground_storage is set to false
+        for max_hour in max_hours[carrier]:
+            roundtrip_correction = 0.5 if carrier == "battery" else 1
+            if carrier == "H2":
+                cavern_types = snakemake.params.sector[
+                    "hydrogen_underground_storage_locations"
+                ]
+                fn_h2_cavern = snakemake.input.h2_cavern
+                h2_caverns = get_salt_caverns(cavern_types, fn_h2_cavern)
+                # h2_caverns will be empty pd.Series if hydrogen_underground_storage is set to false
+                n.add(
+                    "StorageUnit",
+                    h2_caverns.index,
+                    suffix=f" {carrier} {max_hour}h",
+                    bus=h2_caverns.index,
+                    carrier=carrier,
+                    p_nom_extendable=True,
+                    p_nom_max=h2_caverns.div(max_hour).values,
+                    capital_cost=costs.at[f"H2 underground {max_hour}h", "fixed"],
+                    marginal_cost=options["marginal_cost_storage"],
+                    efficiency_store=costs.at[lookup_store[carrier], "efficiency"]
+                    ** roundtrip_correction,
+                    efficiency_dispatch=costs.at[lookup_dispatch[carrier], "efficiency"]
+                    ** roundtrip_correction,
+                    max_hours=max_hour,
+                    cyclic_state_of_charge=True,
+                    lifetime=costs.at["hydrogen storage underground", "lifetime"],
+                )
+                # hydrogen stored overground (where not already underground)
+                nodes_ = h2_caverns.index.symmetric_difference(nodes)
+
+            else:
+                nodes_ = nodes
+
+            cost_carrier = "H2 tank" if carrier == "H2" else carrier
             n.add(
                 "StorageUnit",
-                h2_caverns.index,
-                suffix=" " + carrier,
-                bus=h2_caverns.index,
+                nodes_,
+                suffix=f" {carrier} {max_hour}h",
+                bus=nodes_,
                 carrier=carrier,
                 p_nom_extendable=True,
-                p_nom_max=h2_caverns.div(max_hours[carrier]).values,
-                capital_cost=costs.at["H2 underground", "fixed"],
+                capital_cost=costs.at[f"{cost_carrier} {max_hour}h", "fixed"],
                 marginal_cost=options["marginal_cost_storage"],
                 efficiency_store=costs.at[lookup_store[carrier], "efficiency"]
                 ** roundtrip_correction,
                 efficiency_dispatch=costs.at[lookup_dispatch[carrier], "efficiency"]
                 ** roundtrip_correction,
-                max_hours=max_hours[carrier],
+                max_hours=max_hour,
                 cyclic_state_of_charge=True,
-                lifetime=costs.at["hydrogen storage underground", "lifetime"],
+                lifetime=costs.at[f"{cost_carrier} {max_hour}h", "lifetime"],
             )
-            # hydrogen stored overground (where not already underground)
-            nodes_ = h2_caverns.index.symmetric_difference(nodes)
-
-        else:
-            nodes_ = nodes
-
-        cost_carrier = "H2 tank" if carrier == "H2" else carrier
-        n.add(
-            "StorageUnit",
-            nodes_,
-            suffix=" " + carrier,
-            bus=nodes_,
-            carrier=carrier,
-            p_nom_extendable=True,
-            capital_cost=costs.at[cost_carrier, "fixed"],
-            marginal_cost=options["marginal_cost_storage"],
-            efficiency_store=costs.at[lookup_store[carrier], "efficiency"]
-            ** roundtrip_correction,
-            efficiency_dispatch=costs.at[lookup_dispatch[carrier], "efficiency"]
-            ** roundtrip_correction,
-            max_hours=max_hours[carrier],
-            cyclic_state_of_charge=True,
-            lifetime=costs.at[cost_carrier, "lifetime"],
-        )
 
 
 def add_stores(n, costs, carriers):
@@ -4682,6 +4686,7 @@ def add_enhanced_geothermal(n, egs_potentials, egs_overlap, costs):
                 cyclic_state_of_charge=True,
             )
 
+
 def get_capacities_from_elec(n, carriers, component):
     """
     Gets capacities and efficiencies for {carrier} in n.{component} that were
@@ -4704,6 +4709,7 @@ def get_capacities_from_elec(n, carriers, component):
         )[eff_col]
 
     return capacity_dict, efficiency_dict
+
 
 # %%
 if __name__ == "__main__":

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -8,6 +8,7 @@ technologies for the buildings, transport and industry sectors.
 """
 
 import logging
+import warnings
 import os
 from itertools import product
 from types import SimpleNamespace
@@ -4739,7 +4740,14 @@ if __name__ == "__main__":
     pop_layout = pd.read_csv(snakemake.input.clustered_pop_layout, index_col=0)
     nhours = n.snapshot_weightings.generators.sum()
     nyears = nhours / 8760
-
+    # deprecation warning and casting float values to list of float values for max_hours per carrier
+    for carrier in snakemake.params.max_hours:
+        if not isinstance(snakemake.params.max_hours[carrier], list):
+            warnings.warn(
+                "The 'max_hours' configuration as a float is deprecated and will be removed in future versions. Please use a list instead.",
+                DeprecationWarning,
+            )
+            snakemake.params.max_hours[carrier] = [snakemake.params.max_hours[carrier]]
     costs = prepare_costs(
         snakemake.input.costs,
         snakemake.params,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1396,7 +1396,7 @@ def insert_electricity_distribution_grid(n, costs):
                 efficiency_dispatch=costs.at["home battery inverter", "efficiency"] ** 0.5,
                 max_hours=max_hour,
                 cyclic_state_of_charge=True,
-                lifetime=costs.at["li-ion home battery storage", "lifetime"],
+                lifetime=costs.at["home battery storage", "lifetime"],
             )
 
 


### PR DESCRIPTION
Addresses https://github.com/open-energy-transition/form-energy-storage/issues/13. I tested this locally with this initial  implementation and it seems to work fine. This PR might need some adjustments before merging once we have input data from FE as they might have different cost assumptions for the different archetypes wich is not considered in this PR yet.

## Changes proposed in this Pull Request
The functionality is added  to specify different `max_hour` archetypes for storage technologies by giving a list of max_hours in the config file for each storage technology. For each of the max_hour archetypes an own set of StorageUnits is added as for example: `<node> battery 4h` and `<node> battery 6h`.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
