### PR TITLE
overwrite cost table attributes specified in config in prepare_costs and load_costs

### DIFF
--- a/config/config.form.yaml
+++ b/config/config.form.yaml
@@ -184,6 +184,14 @@ costs:
   # Marginal and capital costs can be overwritten
   # capital_cost:
   #   onwind: 500
+  fuel:
+    OCGT: 38.84 # https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:52022SC0230 (Annex)
+    CCGT: 38.84
+    gas: 38.84
+    coal: 24.57 # https://businessanalytiq.com/procurementanalytics/index/subbituminous-coal-price-index/
+    lignite: 22.11 # https://businessanalytiq.com/procurementanalytics/index/lignite-coal-price-index/
+    nuclear: 1.75 # https://markets.businessinsider.com/commodities/uranium-price
+    uranium: 1.75
   marginal_cost:
     solar: 0.01
     onwind: 0.015

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -243,7 +243,6 @@ def load_costs(tech_costs, config, max_hours, Nyears=1.0):
     for attr in ("investment", "lifetime", "FOM", "VOM", "efficiency", "fuel"):
         overwrites = config.get(attr)
         if overwrites is not None:
-            breakpoint()
             overwrites = pd.Series(overwrites)
             costs.loc[overwrites.index, attr] = overwrites
             logger.info(

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -240,6 +240,16 @@ def load_costs(tech_costs, config, max_hours, Nyears=1.0):
     costs.loc[costs.unit.str.contains("/GW"), "value"] /= 1e3
     costs.unit = costs.unit.str.replace("/GW", "/MW")
 
+    for attr in ("investment", "lifetime", "FOM", "VOM", "efficiency", "fuel"):
+        overwrites = params["costs"].get(attr)
+        if overwrites is not None:
+            breakpoint()
+            overwrites = pd.Series(overwrites)
+            costs.loc[overwrites.index, attr] = overwrites
+            logger.info(
+                f"Overwriting {attr} of {overwrites.index} to {overwrites.values}"
+            )
+
     fill_values = config["fill_values"]
     costs = costs.value.unstack().fillna(fill_values)
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -240,6 +240,9 @@ def load_costs(tech_costs, config, max_hours, Nyears=1.0):
     costs.loc[costs.unit.str.contains("/GW"), "value"] /= 1e3
     costs.unit = costs.unit.str.replace("/GW", "/MW")
 
+    fill_values = config["fill_values"]
+    costs = costs.value.unstack().fillna(fill_values)
+
     for attr in ("investment", "lifetime", "FOM", "VOM", "efficiency", "fuel"):
         overwrites = config.get(attr)
         if overwrites is not None:
@@ -248,9 +251,6 @@ def load_costs(tech_costs, config, max_hours, Nyears=1.0):
             logger.info(
                 f"Overwriting {attr} of {overwrites.index} to {overwrites.values}"
             )
-
-    fill_values = config["fill_values"]
-    costs = costs.value.unstack().fillna(fill_values)
 
     costs["capital_cost"] = (
         (

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -241,7 +241,7 @@ def load_costs(tech_costs, config, max_hours, Nyears=1.0):
     costs.unit = costs.unit.str.replace("/GW", "/MW")
 
     for attr in ("investment", "lifetime", "FOM", "VOM", "efficiency", "fuel"):
-        overwrites = params["costs"].get(attr)
+        overwrites = config.get(attr)
         if overwrites is not None:
             breakpoint()
             overwrites = pd.Series(overwrites)
@@ -1001,7 +1001,7 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
-        snakemake = mock_snakemake("add_electricity", clusters=100)
+        snakemake = mock_snakemake("add_electricity", clusters=52, configfiles="config/config.form.yaml")
     configure_logging(snakemake)
     set_scenario_config(snakemake)
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -1001,7 +1001,7 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
-        snakemake = mock_snakemake("add_electricity", clusters=52, configfiles="config/config.form.yaml")
+        snakemake = mock_snakemake("add_electricity", clusters=100)
     configure_logging(snakemake)
     set_scenario_config(snakemake)
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1093,7 +1093,6 @@ def prepare_costs(cost_file, params, nyears):
     for attr in ("investment", "lifetime", "FOM", "VOM", "efficiency", "fuel"):
         overwrites = params["costs"].get(attr)
         if overwrites is not None:
-            breakpoint()
             overwrites = pd.Series(overwrites)
             costs.loc[overwrites.index, attr] = overwrites
             logger.info(

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1090,6 +1090,16 @@ def prepare_costs(cost_file, params, nyears):
 
     costs = costs.fillna(params["costs"]["fill_values"])
 
+    for attr in ("investment", "lifetime", "FOM", "VOM", "efficiency", "fuel"):
+        overwrites = params["costs"].get(attr)
+        if overwrites is not None:
+            breakpoint()
+            overwrites = pd.Series(overwrites)
+            costs.loc[overwrites.index, attr] = overwrites
+            logger.info(
+                f"Overwriting {attr} of {overwrites.index} to {overwrites.values}"
+            )
+
     def annuity_factor(v):
         return calculate_annuity(v["lifetime"], v["discount rate"]) + v["FOM"] / 100
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
Adds overwrites specified in the config file based on this implementation in PyPSA-Earth: https://github.com/pypsa-meets-earth/pypsa-earth/blob/d9a364cec2df1866c77d53226e509275795f2dbd/scripts/add_electricity.py#L148-L157

Addresses https://github.com/open-energy-transition/form-energy-storage/issues/10
## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
