### PR TITLE
fix deprecation warning inside prepare_cost and load_cost functions

### DIFF
--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -235,6 +235,14 @@ def add_co2_emissions(n, costs, carriers):
 
 
 def load_costs(tech_costs, config, max_hours, Nyears=1.0):
+    # deprecation warning and casting float values to list of float values for max_hours per carrier
+    for carrier in max_hours:
+        if not isinstance(max_hours[carrier], list):
+            warnings.warn(
+                "The 'max_hours' configuration as a float is deprecated and will be removed in future versions. Please use a list instead.",
+                DeprecationWarning,
+            )
+            max_hours[carrier] = [max_hours[carrier]]
     # set all asset costs and other parameters
     costs = pd.read_csv(tech_costs, index_col=[0, 1]).sort_index()
 
@@ -1086,15 +1094,6 @@ if __name__ == "__main__":
     set_scenario_config(snakemake)
 
     params = snakemake.params
-    max_hours = params.electricity["max_hours"]
-    # deprecation warning and casting float values to list of float values for max_hours per carrier
-    for carrier in max_hours:
-        if not isinstance(max_hours[carrier], list):
-            warnings.warn(
-                "The 'max_hours' configuration as a float is deprecated and will be removed in future versions. Please use a list instead.",
-                DeprecationWarning,
-            )
-            max_hours[carrier] = [max_hours[carrier]]
     landfall_lengths = {
         tech: settings["landfall_length"]
         for tech, settings in params.renewable.items()
@@ -1111,9 +1110,10 @@ if __name__ == "__main__":
     costs = load_costs(
         snakemake.input.tech_costs,
         params.costs,
-        max_hours,
+        params.electricity["max_hours"],
         Nyears,
     )
+    max_hours = params.electricity["max_hours"]
 
     ppl = load_and_aggregate_powerplants(
         snakemake.input.powerplants,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1077,6 +1077,14 @@ def cycling_shift(df, steps=1):
 
 
 def prepare_costs(cost_file, params, nyears):
+    # deprecation warning and casting float values to list of float values for max_hours per carrier
+    for carrier in params.max_hours:
+        if not isinstance(params.max_hours[carrier], list):
+            warnings.warn(
+                "The 'max_hours' configuration as a float is deprecated and will be removed in future versions. Please use a list instead.",
+                DeprecationWarning,
+            )
+            params.max_hours[carrier] = [params.max_hours[carrier]]
     # set all asset costs and other parameters
     costs = pd.read_csv(cost_file, index_col=[0, 1]).sort_index()
 
@@ -4831,14 +4839,6 @@ if __name__ == "__main__":
     pop_layout = pd.read_csv(snakemake.input.clustered_pop_layout, index_col=0)
     nhours = n.snapshot_weightings.generators.sum()
     nyears = nhours / 8760
-    # deprecation warning and casting float values to list of float values for max_hours per carrier
-    for carrier in snakemake.params.max_hours:
-        if not isinstance(snakemake.params.max_hours[carrier], list):
-            warnings.warn(
-                "The 'max_hours' configuration as a float is deprecated and will be removed in future versions. Please use a list instead.",
-                DeprecationWarning,
-            )
-            snakemake.params.max_hours[carrier] = [snakemake.params.max_hours[carrier]]
     costs = prepare_costs(
         snakemake.input.costs,
         snakemake.params,


### PR DESCRIPTION
Fixes depreaction warning for use outside of prepare_sector_network.py and add_electricity.py

## Checklist

- [x] I tested my contribution locally and it works as intended.