### PR TITLE
Fix versions of pypsa and snakemake

### DIFF
--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -11,7 +11,7 @@ dependencies:
 - pip
 
 - atlite>=0.2.9
-- pypsa>=0.28
+- pypsa==0.28
 - linopy
 - dask
 
@@ -20,7 +20,7 @@ dependencies:
 - openpyxl!=3.1.1
 - pycountry
 - seaborn
-- snakemake-minimal>=8.11
+- snakemake-minimal==8.10
 - memory_profiler
 - yaml
 - pytables

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -12,7 +12,7 @@ dependencies:
 
 - atlite>=0.2.9
 - pypsa==0.28
-- linopy
+- linopy==0.3.10
 - dask
 
   # Dependencies of the workflow itself
@@ -25,11 +25,11 @@ dependencies:
 - yaml
 - pytables
 - lxml
-- powerplantmatching>=0.5.15
+- powerplantmatching==0.5.15
 - numpy
 - pandas>=2.1
 - geopandas>=0.11.0, <1
-- xarray>=2023.11.0
+- xarray==2023.11.0
 - rioxarray
 - netcdf4
 - networkx

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -20,7 +20,7 @@ dependencies:
 - openpyxl!=3.1.1
 - pycountry
 - seaborn
-- snakemake-minimal==8.10
+- snakemake-minimal==8.11
 - memory_profiler
 - yaml
 - pytables
@@ -59,7 +59,8 @@ dependencies:
 
 
 - pip:
-  - tsam>=2.3.1
+  - tsam==2.3.1
+  - snakemake-interface-storage-plugins==3.3.0
   - snakemake-storage-plugin-http
   - snakemake-executor-plugin-slurm
   - snakemake-executor-plugin-cluster-generic


### PR DESCRIPTION
## Changes proposed in this Pull Request
Good day. This PR fixed pypsa and snakemake versions to 0.28 and 8.10, respectively. It prevents errors while executing the rules.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `envs/environment.yaml`.
- [ ] A release note `doc/release_notes.rst` is added.
