### PR TITLE
doc: update license identifier

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,6 @@ Closes # (if applicable).
 - [ ] Changed dependencies are added to `envs/environment.yaml`.
 - [ ] Changes in configuration options are added in `config/config.default.yaml`.
 - [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
-- [ ] The OET license identifier is added to all edited or newly created code files.
+- [ ] OET license identifier is added to all edited or newly created code files.
 - [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
 - [ ] A release note `doc/release_notes.rst` is added.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,5 +10,6 @@ Closes # (if applicable).
 - [ ] Changed dependencies are added to `envs/environment.yaml`.
 - [ ] Changes in configuration options are added in `config/config.default.yaml`.
 - [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
+- [ ] The OET license identifier is added to all edited or newly created code files.
 - [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
 - [ ] A release note `doc/release_notes.rst` is added.

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 SPDX-License-Identifier: CC-BY-4.0
 -->
 

--- a/Snakefile
+++ b/Snakefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/config/plotting.default.yaml
+++ b/config/plotting.default.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: : 2017-2024 The PyPSA-Eur Authors
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/doc/data-retrieval.rst
+++ b/doc/data-retrieval.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+  SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+  SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/doc/preparation.rst
+++ b/doc/preparation.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+  SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,6 +1,6 @@
 
 ..
-  SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+  SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/doc/retrieve.rst
+++ b/doc/retrieve.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+  SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/doc/sector.rst
+++ b/doc/sector.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+  SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/report/references.bib
+++ b/report/references.bib
@@ -1,4 +1,4 @@
-% SPDX-FileCopyrightText:  Open Energy Transition gGmbH
+% SPDX-FileCopyrightText: Open Energy Transition gGmbH
 %
 % SPDX-License-Identifier: MIT
 

--- a/report/report.tex
+++ b/report/report.tex
@@ -1,4 +1,4 @@
-% SPDX-FileCopyrightText:  Open Energy Transition gGmbH
+% SPDX-FileCopyrightText: Open Energy Transition gGmbH
 %
 % SPDX-License-Identifier: MIT
 

--- a/report/sections/.gitkeep
+++ b/report/sections/.gitkeep
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText:  Open Energy Transition gGmbH
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH
 #
 # SPDX-License-Identifier: CC0-1.0

--- a/report/sections/abstract.tex
+++ b/report/sections/abstract.tex
@@ -1,4 +1,4 @@
-% SPDX-FileCopyrightText:  Open Energy Transition gGmbH
+% SPDX-FileCopyrightText: Open Energy Transition gGmbH
 %
 % SPDX-License-Identifier: MIT
 

--- a/report/sections/conclusion.tex
+++ b/report/sections/conclusion.tex
@@ -1,4 +1,4 @@
-% SPDX-FileCopyrightText:  Open Energy Transition gGmbH
+% SPDX-FileCopyrightText: Open Energy Transition gGmbH
 %
 % SPDX-License-Identifier: MIT
 

--- a/report/sections/discussion.tex
+++ b/report/sections/discussion.tex
@@ -1,4 +1,4 @@
-% SPDX-FileCopyrightText:  Open Energy Transition gGmbH
+% SPDX-FileCopyrightText: Open Energy Transition gGmbH
 %
 % SPDX-License-Identifier: MIT
 

--- a/report/sections/introduction.tex
+++ b/report/sections/introduction.tex
@@ -1,4 +1,4 @@
-% SPDX-FileCopyrightText:  Open Energy Transition gGmbH
+% SPDX-FileCopyrightText: Open Energy Transition gGmbH
 %
 % SPDX-License-Identifier: MIT
 

--- a/report/sections/methods.tex
+++ b/report/sections/methods.tex
@@ -1,4 +1,4 @@
-% SPDX-FileCopyrightText:  Open Energy Transition gGmbH
+% SPDX-FileCopyrightText: Open Energy Transition gGmbH
 %
 % SPDX-License-Identifier: MIT
 

--- a/report/sections/results.tex
+++ b/report/sections/results.tex
@@ -1,4 +1,4 @@
-% SPDX-FileCopyrightText:  Open Energy Transition gGmbH
+% SPDX-FileCopyrightText: Open Energy Transition gGmbH
 %
 % SPDX-License-Identifier: MIT
 

--- a/report/sections/supplementary.tex
+++ b/report/sections/supplementary.tex
@@ -1,4 +1,4 @@
-% SPDX-FileCopyrightText:  Open Energy Transition gGmbH
+% SPDX-FileCopyrightText: Open Energy Transition gGmbH
 %
 % SPDX-License-Identifier: MIT
 

--- a/report/static/.gitkeep
+++ b/report/static/.gitkeep
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText:  Open Energy Transition gGmbH
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH
 #
 # SPDX-License-Identifier: CC0-1.0

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 

--- a/rules/postprocess.smk
+++ b/rules/postprocess.smk
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 

--- a/rules/report.smk
+++ b/rules/report.smk
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText:  Open Energy Transition gGmbH
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH
 #
 # SPDX-License-Identifier: MIT
 

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 

--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 

--- a/rules/solve_perfect.smk
+++ b/rules/solve_perfect.smk
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 rule add_existing_baseyear:

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 

--- a/scripts/build_district_heat_share.py
+++ b/scripts/build_district_heat_share.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/scripts/build_electricity_demand_base.py
+++ b/scripts/build_electricity_demand_base.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/scripts/build_energy_totals.py
+++ b/scripts/build_energy_totals.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/scripts/build_existing_heating_distribution.py
+++ b/scripts/build_existing_heating_distribution.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/scripts/build_industrial_energy_demand_per_country_today.py
+++ b/scripts/build_industrial_energy_demand_per_country_today.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/scripts/build_industrial_energy_demand_per_node_today.py
+++ b/scripts/build_industrial_energy_demand_per_node_today.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/scripts/build_industrial_production_per_node.py
+++ b/scripts/build_industrial_production_per_node.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 

--- a/scripts/plot_balance_map.py
+++ b/scripts/plot_balance_map.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/scripts/plot_hydrogen_network.py
+++ b/scripts/plot_hydrogen_network.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/scripts/retrieve_bidding_zones.py
+++ b/scripts/retrieve_bidding_zones.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/test/test_base_network.py
+++ b/test/test_base_network.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR updates the license identifiers of the files in this repository. 

The proposed license Identifier for entirely newly added files is:
```
# SPDX-FileCopyrightText: Open Energy Transition gGmbH
#
# SPDX-License-Identifier: MIT
```
For files that already existed where changes and new features were introduced by OET the proposed license identifier is:
```
# SPDX-FileCopyrightText: Open Energy Transition gGmbH and contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
#
# SPDX-License-Identifier: MIT
```

This PR follows PyPSA-Eur licensing convention for dotfiles and yaml files to use `CC0-1.0` and RST files to use `CC-BY-4.0` licensing instead of `MIT`.

The PR also adds a new item to the [PR template checklist](https://github.com/open-energy-transition/pypsa-eur/blob/master/.github/pull_request_template.md).

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
