### PR TITLE
chore: update REUSE.toml for oet report template

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -23,3 +23,10 @@ path = [
 ]
 SPDX-FileCopyrightText = "The PyPSA-Eur Authors"
 SPDX-License-Identifier = "CC0-1.0"
+
+[[annotations]]
+path = [
+    "report/**",
+]
+SPDX-FileCopyrightText = "Open Energy Transition gGmbH"
+SPDX-License-Identifier = "MIT"


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR brings the reuse licensing information back in line with the custom OET report template.

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] OET license identifier is added to all edited or newly created code files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
