### PR TITLE
Add gitleaks config to ignore lockfiles

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH
+#
+# SPDX-License-Identifier: CC0-1.0
+
+title = "Custom gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlists]
+description = "Custom global allow lists"
+paths = [
+    '''(.*?).lock.yaml'''
+]


### PR DESCRIPTION
New `gitleaks` hook was detecting "leaks" in _unchanged_ and _untracked_ environment lockfiles. They are false positives that aren't even staged for commit. I've added a config file to allow "secrets" in lockfiles to avoid these false positives, on the (reasonable) assumption that nobody plans to store any sensitive data in automatically generated lock files...


<details><summary>Traceback without config</summary>
<p>

```sh
Detect hardcoded secrets.................................................Failed
- hook id: gitleaks
- exit code: 1

○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

Finding:     - google-api-core=REDACTED
Secret:      REDACTED
RuleID:      generic-api-key
Entropy:     3.826875
File:        envs/osx-64.lock.yaml
Line:        151
Fingerprint: envs/osx-64.lock.yaml:generic-api-key:151

Finding:     - google-auth=REDACTED
Secret:      REDACTED
RuleID:      generic-api-key
Entropy:     3.932138
File:        envs/osx-64.lock.yaml
Line:        152
Fingerprint: envs/osx-64.lock.yaml:generic-api-key:152

Finding:     - googleapis-common-protos=REDACTED
Secret:      REDACTED
RuleID:      generic-api-key
Entropy:     3.681881
File:        envs/osx-64.lock.yaml
Line:        157
Fingerprint: envs/osx-64.lock.yaml:generic-api-key:157

Finding:     - google-api-core=REDACTED
Secret:      REDACTED
RuleID:      generic-api-key
Entropy:     3.826875
File:        envs/osx-arm64.lock.yaml
Line:        151
Fingerprint: envs/osx-arm64.lock.yaml:generic-api-key:151

Finding:     - google-auth=REDACTED
Secret:      REDACTED
RuleID:      generic-api-key
Entropy:     3.932138
File:        envs/osx-arm64.lock.yaml
Line:        152
Fingerprint: envs/osx-arm64.lock.yaml:generic-api-key:152

Finding:     - googleapis-common-protos=REDACTED
Secret:      REDACTED
RuleID:      generic-api-key
Entropy:     3.681881
File:        envs/osx-arm64.lock.yaml
Line:        157
Fingerprint: envs/osx-arm64.lock.yaml:generic-api-key:157

Finding:     - google-api-core=REDACTED
Secret:      REDACTED
RuleID:      generic-api-key
Entropy:     3.826875
File:        envs/linux-64.lock.yaml
Line:        160
Fingerprint: envs/linux-64.lock.yaml:generic-api-key:160

Finding:     - google-auth=REDACTED
Secret:      REDACTED
RuleID:      generic-api-key
Entropy:     3.932138
File:        envs/linux-64.lock.yaml
Line:        161
Fingerprint: envs/linux-64.lock.yaml:generic-api-key:161

Finding:     - googleapis-common-protos=REDACTED
Secret:      REDACTED
RuleID:      generic-api-key
Entropy:     3.681881
File:        envs/linux-64.lock.yaml
Line:        166
Fingerprint: envs/linux-64.lock.yaml:generic-api-key:166

Finding:     - google-api-core=REDACTED
Secret:      REDACTED
RuleID:      generic-api-key
Entropy:     3.826875
File:        envs/win-64.lock.yaml
Line:        141
Fingerprint: envs/win-64.lock.yaml:generic-api-key:141

Finding:     - google-auth=REDACTED
Secret:      REDACTED
RuleID:      generic-api-key
Entropy:     3.932138
File:        envs/win-64.lock.yaml
Line:        142
Fingerprint: envs/win-64.lock.yaml:generic-api-key:142

Finding:     - googleapis-common-protos=REDACTED
Secret:      REDACTED
RuleID:      generic-api-key
Entropy:     3.681881
File:        envs/win-64.lock.yaml
Line:        147
Fingerprint: envs/win-64.lock.yaml:generic-api-key:147

9:16AM INF 0 commits scanned.
9:16AM INF scanned ~21973 bytes (21.97 KB) in 34.4ms
9:16AM WRN leaks found: 12
```

</p>
</details> 

## Checklist

<!-- Remove what doesn't apply. -->

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
