### PR TITLE
Adjust file paths to work on Windows

### DIFF
--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -60,7 +60,7 @@ def input_base_network(w):
     components = {"buses", "lines", "links", "converters", "transformers"}
     if base_network == "osm":
         OSM_DATASET = dataset_version("osm")
-        inputs = {c: f"{OSM_DATASET['folder']}/{c}.csv" for c in components}
+        inputs = {c: Path(f"{OSM_DATASET['folder']}/{c}.csv").as_posix() for c in components}
     elif base_network == "tyndp":
         inputs = {c: resources(f"tyndp/build/{c}.csv") for c in components}
     elif base_network == "entsoegridkit":
@@ -285,7 +285,7 @@ rule determine_availability_matrix:
         unpack(input_ua_md_availability_matrix),
         corine=ancient(f"{rules.retrieve_corine.output['tif_file']}"),
         natura=lambda w: (
-            NATURA_DATASET["folder"] / "natura.tiff"
+            Path(NATURA_DATASET["folder"] / "natura.tiff").as_posix()
             if config_provider("renewable", w.technology, "natura")(w)
             else []
         ),
@@ -747,8 +747,8 @@ rule add_electricity:
         unpack(input_class_regions),
         unpack(input_conventional),
         base_network=resources("networks/base_s_{clusters}.nc"),
-        tech_costs=lambda w: COSTS_DATASET["folder"]
-        / f"costs_{config_provider('costs', 'year')(w)}.csv",
+        tech_costs=lambda w: Path(COSTS_DATASET["folder"]
+        / f"costs_{config_provider('costs', 'year')(w)}.csv").as_posix(),
         regions=resources("regions_onshore_base_s_{clusters}.geojson"),
         powerplants=resources("powerplants_s_{clusters}.csv"),
         hydro_capacities=ancient("data/hydro_capacities.csv"),
@@ -793,8 +793,8 @@ rule prepare_network:
         transmission_limit=config_provider("electricity", "transmission_limit"),
     input:
         resources("networks/base_s_{clusters}_elec.nc"),
-        tech_costs=lambda w: COSTS_DATASET["folder"]
-        / f"costs_{config_provider('costs', 'year')(w)}.csv",
+        tech_costs=lambda w: Path(COSTS_DATASET["folder"]
+        / f"costs_{config_provider('costs', 'year')(w)}.csv").as_posix(),
         co2_price=lambda w: resources("co2_price.csv") if "Ept" in w.opts else [],
     output:
         resources("networks/base_s_{clusters}_elec_{opts}.nc"),

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1610,12 +1610,12 @@ rule prepare_sector_network:
         biomass_potentials=resources(
             "biomass_potentials_s_{clusters}_{planning_horizons}.csv"
         ),
-        costs=lambda w: COSTS_DATASET["folder"]
+        costs=lambda w: Path(COSTS_DATASET["folder"]
         / (
             "costs_{}.csv".format(config_provider("costs", "year")(w))
             if config_provider("foresight")(w) == "overnight"
             else "costs_{planning_horizons}.csv"
-        ),
+        )).as_posix(),
         h2_cavern=resources("salt_cavern_potentials_s_{clusters}.csv"),
         busmap_s=resources("busmap_base_s.csv"),
         busmap=resources("busmap_base_s_{clusters}.csv"),


### PR DESCRIPTION
## Description

As of right now, I run into the issues listed below when trying to run the code on Windows.
They all occure, when Snakemake changes a filepath from posix style to the Windows style (similar to #[1602](https://github.com/PyPSA/pypsa-eur/pull/1602)). To fix this, I've applied the same fix where I enforce posix style paths using `Path(...).as_posix()`. This resolves the issue when dry-running snakemake, I am still in the process of a full test run.

I am aware that you are not that big fans of the solution mentioned above, but its the only one I've found so far that solves it reliably.

## Errors

<details>
<summary>Click to expand error messages</summary>

```
Missing input files for rule base_network:
    output: resources/Versioning/Test01/networks/base.nc, resources/Versioning/Test01/regions_onshore.geojson, resources/Versioning/Test01/regions_offshore.geojson, resources/Versioning/Test01/admin_shapes.geojson      
    affected files:
        data\osm\archive\0.6/buses.csv
        data\osm\archive\0.6/converters.csv
        data\osm\archive\0.6/lines.csv
        data\osm\archive\0.6/links.csv
        data\osm\archive\0.6/transformers.csv

Missing input files for rule determine_availability_matrix:
    output: resources/Versioning/Test01/availability_matrix_5_offwind-ac.nc
    wildcards: clusters=5, technology=offwind-ac
    affected files:
        data\natura\archive\2025-08-15\natura.tiff

Missing input files for rule add_electricity:
    output: resources/Versioning/Test01/networks/base_s_5_elec.nc
    wildcards: clusters=5
    affected files:
        data\costs\primary\v0.13.3\costs_2050.csv

Missing input files for rule prepare_network:
    output: resources/Versioning/Test01/networks/base_s_5_elec_.nc
    wildcards: clusters=5, opts=
    affected files:
        data\costs\primary\v0.13.3\costs_2050.csv

Missing input files for rule prepare_sector_network:
    output: resources/Versioning/Test01/networks/base_s_5___2050.nc
    wildcards: clusters=5, opts=, sector_opts=, planning_horizons=2050
    affected files:
        data\costs\primary\v0.13.3\costs_2050.csv
```
</details> 


Closes # (if applicable).

## Changes proposed in this Pull Request
- enforce posix-style filepaths

## Checklist

<!-- Remove what doesn't apply. -->

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
